### PR TITLE
Client-side search with filter persistence

### DIFF
--- a/src/routes/tags.rs
+++ b/src/routes/tags.rs
@@ -164,7 +164,7 @@ async fn show_tag(
         .into_iter()
         .map(|r| {
             let (entry, count) = r.into_entry_and_count();
-            build_entry_view(entry, count, now)
+            build_entry_view(entry, count, vec![name.clone()], now)
         })
         .collect();
 

--- a/static/style.css
+++ b/static/style.css
@@ -106,35 +106,93 @@ header nav a.active {
 
 .header-actions {
     display: flex;
+    justify-content: space-between;
+    align-items: baseline;
     gap: 1rem;
     margin-top: 0.75rem;
 }
 
-#search-input {
-    flex: 1;
-    padding: 0.25rem 0.5rem;
-    border: var(--border);
-    border-radius: var(--radius);
+/* Search trigger */
+.search-trigger {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    cursor: pointer;
+}
+
+.search-icon {
+    color: var(--gray-400);
+    flex-shrink: 0;
+    transition: color 0.15s ease;
+}
+
+.search-trigger:hover .search-icon,
+.search-trigger.active .search-icon {
+    color: var(--gray-600);
+}
+
+.search-swap {
+    display: grid;
+    min-width: 10rem;
+    justify-items: end;
+}
+
+.search-swap > * {
+    grid-row: 1;
+    grid-column: 1;
+    transition: opacity 0.15s ease;
+}
+
+.search-trigger:hover .search-swap .date,
+.search-trigger.active .search-swap .date {
+    opacity: 0;
+    pointer-events: none;
+}
+
+.search-swap .search-field {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 100%;
+    opacity: 0;
+    pointer-events: none;
     font-size: 0.8125rem;
     font-family: inherit;
-    background: var(--white);
     color: var(--black);
+    background: transparent;
+    border: none;
+    border-bottom: 1px solid transparent;
+    border-radius: 0;
+    padding: 0 0 1px 0;
+    text-align: right;
+    box-shadow: none;
 }
 
-#search-input:focus {
+.search-swap .search-field:focus {
     outline: none;
-    border-color: var(--gray-400);
+    box-shadow: none;
 }
 
-#search-input::placeholder {
+.search-swap .search-field::placeholder {
     color: var(--gray-400);
+}
+
+.search-swap .search-field::-webkit-search-cancel-button,
+.search-swap .search-field::-webkit-search-decoration {
+    -webkit-appearance: none;
+    display: none;
+}
+
+.search-trigger:hover .search-swap .search-field,
+.search-trigger.active .search-swap .search-field {
+    opacity: 1;
+    pointer-events: auto;
+    border-bottom-color: var(--gray-200);
 }
 
 .header-actions a {
     font-size: 0.8125rem;
     color: var(--gray-600);
     text-decoration: none;
-    white-space: nowrap;
 }
 
 .header-actions a:hover {
@@ -143,6 +201,9 @@ header nav a.active {
 
 @media (max-width: 480px) {
     .date {
+        display: none;
+    }
+    .search-trigger {
         display: none;
     }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -110,10 +110,31 @@ header nav a.active {
     margin-top: 0.75rem;
 }
 
+#search-input {
+    flex: 1;
+    padding: 0.25rem 0.5rem;
+    border: var(--border);
+    border-radius: var(--radius);
+    font-size: 0.8125rem;
+    font-family: inherit;
+    background: var(--white);
+    color: var(--black);
+}
+
+#search-input:focus {
+    outline: none;
+    border-color: var(--gray-400);
+}
+
+#search-input::placeholder {
+    color: var(--gray-400);
+}
+
 .header-actions a {
     font-size: 0.8125rem;
     color: var(--gray-600);
     text-decoration: none;
+    white-space: nowrap;
 }
 
 .header-actions a:hover {

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,7 +21,9 @@
                     <a href="/tags">Tags</a>
                     <a href="/collections">Collections</a>
                     {% endif %}
+                    {% block nav_end %}
                     <span class="date" id="clock"></span>
+                    {% endblock %}
                 </nav>
             </div>
             {% block header_actions %}{% endblock %}

--- a/templates/entries/entry.html
+++ b/templates/entries/entry.html
@@ -1,4 +1,4 @@
-<div class="entry {% if !entry.is_available %}unavailable{% endif %}" id="entry-{{ entry.id }}">
+<div class="entry {% if !entry.is_available %}unavailable{% endif %}" id="entry-{{ entry.id }}" data-search="{{ entry.title }} {{ entry.url }} {{ entry.description.as_deref().unwrap_or("") }} {{ entry.tags.join(" ") }}">
     <div class="entry-header">
         <div class="entry-title">
             <a href="{{ entry.url }}" target="_blank" rel="noopener noreferrer"

--- a/templates/entries/list.html
+++ b/templates/entries/list.html
@@ -16,6 +16,7 @@
 
 {% block header_actions %}
 <div class="header-actions">
+    <input type="search" id="search-input" placeholder="Search links..." autocomplete="off" spellcheck="false">
     <a href="/entries/new">+ New Link</a>
 </div>
 {% endblock %}
@@ -40,5 +41,24 @@
         {% endfor %}
     {% endif %}
 </div>
+
+<script>
+(function() {
+    var input = document.getElementById('search-input');
+    var list = document.getElementById('entry-list');
+    var timer;
+    input.addEventListener('input', function() {
+        clearTimeout(timer);
+        timer = setTimeout(function() {
+            var q = input.value.toLowerCase();
+            var entries = list.querySelectorAll('.entry');
+            for (var i = 0; i < entries.length; i++) {
+                var haystack = entries[i].getAttribute('data-search').toLowerCase();
+                entries[i].style.display = (!q || haystack.indexOf(q) !== -1) ? '' : 'none';
+            }
+        }, 150);
+    });
+})();
+</script>
 {% endblock %}
 

--- a/templates/entries/list.html
+++ b/templates/entries/list.html
@@ -2,21 +2,27 @@
 
 {% block title %}Interne{% endblock %}
 
-{% block header_left %}
-<div id="view-filter" class="view-filter">
-    <a href="/" class="view-filter-link{% if filter == "ready" %} active{% endif %}" hx-get="/" hx-target="#entry-list" hx-select="#entry-list" hx-select-oob="#view-filter" hx-swap="outerHTML" hx-push-url="true">Ready</a>
-    /
-    <a href="/waiting" class="view-filter-link{% if filter == "waiting" %} active{% endif %}" hx-get="/waiting" hx-target="#entry-list" hx-select="#entry-list" hx-select-oob="#view-filter" hx-swap="outerHTML" hx-push-url="true">Waiting</a>
-    /
-    <a href="/unseen" class="view-filter-link{% if filter == "unseen" %} active{% endif %}" hx-get="/unseen" hx-target="#entry-list" hx-select="#entry-list" hx-select-oob="#view-filter" hx-swap="outerHTML" hx-push-url="true">Unseen</a>
-    /
-    <a href="/all" class="view-filter-link{% if filter == "all" %} active{% endif %}" hx-get="/all" hx-target="#entry-list" hx-select="#entry-list" hx-select-oob="#view-filter" hx-swap="outerHTML" hx-push-url="true">All</a>
+{% block nav_end %}
+<div class="search-trigger" id="search-trigger">
+    <svg class="search-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+    <div class="search-swap">
+        <span class="date" id="clock"></span>
+        <input type="search" class="search-field" id="search-input" placeholder="Search..." autocomplete="off" spellcheck="false">
+    </div>
 </div>
 {% endblock %}
 
 {% block header_actions %}
 <div class="header-actions">
-    <input type="search" id="search-input" placeholder="Search links..." autocomplete="off" spellcheck="false">
+    <div id="view-filter" class="view-filter">
+        <a href="/" class="view-filter-link{% if filter == "ready" %} active{% endif %}" hx-get="/" hx-target="#entry-list" hx-select="#entry-list" hx-swap="outerHTML" hx-push-url="true">Ready</a>
+        /
+        <a href="/waiting" class="view-filter-link{% if filter == "waiting" %} active{% endif %}" hx-get="/waiting" hx-target="#entry-list" hx-select="#entry-list" hx-swap="outerHTML" hx-push-url="true">Waiting</a>
+        /
+        <a href="/unseen" class="view-filter-link{% if filter == "unseen" %} active{% endif %}" hx-get="/unseen" hx-target="#entry-list" hx-select="#entry-list" hx-swap="outerHTML" hx-push-url="true">Unseen</a>
+        /
+        <a href="/all" class="view-filter-link{% if filter == "all" %} active{% endif %}" hx-get="/all" hx-target="#entry-list" hx-select="#entry-list" hx-swap="outerHTML" hx-push-url="true">All</a>
+    </div>
     <a href="/entries/new">+ New Link</a>
 </div>
 {% endblock %}
@@ -44,19 +50,69 @@
 
 <script>
 (function() {
+    var trigger = document.getElementById('search-trigger');
     var input = document.getElementById('search-input');
-    var list = document.getElementById('entry-list');
+    var hovering = false;
     var timer;
+
+    function activate() { trigger.classList.add('active'); }
+    function deactivate() {
+        if (!hovering && !input.value) trigger.classList.remove('active');
+    }
+
+    function filterEntries() {
+        var q = input.value.toLowerCase();
+        var entries = document.getElementById('entry-list').querySelectorAll('.entry');
+        for (var i = 0; i < entries.length; i++) {
+            var haystack = entries[i].getAttribute('data-search').toLowerCase();
+            entries[i].style.display = (!q || haystack.indexOf(q) !== -1) ? '' : 'none';
+        }
+    }
+
+    trigger.addEventListener('mouseenter', function() {
+        hovering = true;
+        activate();
+        input.focus();
+    });
+    trigger.addEventListener('mouseleave', function() {
+        hovering = false;
+        if (document.activeElement !== input) deactivate();
+    });
+    input.addEventListener('focus', activate);
+    input.addEventListener('blur', deactivate);
+
+    // filter entries
     input.addEventListener('input', function() {
         clearTimeout(timer);
-        timer = setTimeout(function() {
-            var q = input.value.toLowerCase();
-            var entries = list.querySelectorAll('.entry');
-            for (var i = 0; i < entries.length; i++) {
-                var haystack = entries[i].getAttribute('data-search').toLowerCase();
-                entries[i].style.display = (!q || haystack.indexOf(q) !== -1) ? '' : 'none';
-            }
-        }, 150);
+        timer = setTimeout(filterEntries, 150);
+    });
+
+    // re-apply search filter after htmx loads new content
+    document.body.addEventListener('htmx:load', function() {
+        if (input.value) filterEntries();
+    });
+
+    // update active filter link (no OOB swap, so we handle it client-side)
+    document.getElementById('view-filter').addEventListener('click', function(e) {
+        var link = e.target.closest('.view-filter-link');
+        if (!link) return;
+        var links = document.querySelectorAll('.view-filter-link');
+        for (var i = 0; i < links.length; i++) links[i].classList.remove('active');
+        link.classList.add('active');
+    });
+
+    // keyboard shortcut: / to focus, Escape to clear
+    document.addEventListener('keydown', function(e) {
+        if (e.key === '/' && document.activeElement.tagName !== 'INPUT' && document.activeElement.tagName !== 'TEXTAREA') {
+            e.preventDefault();
+            activate();
+            input.focus();
+        }
+        if (e.key === 'Escape' && document.activeElement === input) {
+            input.value = '';
+            input.dispatchEvent(new Event('input'));
+            input.blur();
+        }
     });
 })();
 </script>


### PR DESCRIPTION
## Summary
- Adds client-side search filtering for entries (searches title, URL, description, tags)
- Search input replaces the clock in the nav on hover/focus, activated with `/` shortcut
- Fixes bug where search query was lost when switching between Ready/Waiting/Unseen/All filters

## Details
The filter links previously used `hx-select-oob` to OOB-swap `#view-filter`, which detached the triggering `<a>` from the DOM before htmx events could bubble. This broke `htmx:afterSettle` and prevented search re-application after filter switches.

Fix: removed OOB swap, use `htmx:load` to re-apply search after new content loads, and handle the active filter class in JS.

## Known issues
- Brief flicker when switching filters with an active search query — entries appear unfiltered for a frame before `htmx:load` fires and re-applies the filter. `htmx:afterSwap` / `htmx:afterSettle` fire earlier but don't work reliably with `outerHTML` swaps.

## Test plan
- [ ] Type a search query, verify entries filter in real-time
- [ ] With a search query active, click each filter (Ready/Waiting/Unseen/All) — results should stay filtered
- [ ] Clear search with Escape — all entries should reappear
- [ ] `/` keyboard shortcut focuses search input
- [ ] Verify active filter link styling updates on click